### PR TITLE
Replace deprecated `gulp-util`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 'use strict';
 
+var replaceExt    = require('replace-ext');
 var through       = require('through2');
-var gutil         = require('gulp-util');
 var yaml          = require('js-yaml');
 var xtend         = require('xtend');
 var BufferStreams = require('bufferstreams');
-var PluginError   = gutil.PluginError;
+var PluginError   = require('plugin-error');
 var PLUGIN_NAME   = 'gulp-yaml';
 
 
@@ -61,7 +61,7 @@ module.exports = function(options) {
       }
       try {
         file.contents = yaml2json(file.contents, options);
-        file.path = gutil.replaceExtension(file.path, '.json');
+        file.path = replaceExt(file.path, '.json');
       }
       catch (error) {
         this.emit('error', new PluginError(PLUGIN_NAME, error, {showStack: true}));
@@ -82,7 +82,7 @@ module.exports = function(options) {
           else {
             try {
               var parsed = yaml2json(buf, options);
-              file.path = gutil.replaceExtension(file.path, '.json');
+              file.path = replaceExt(file.path, '.json');
               cb(null, parsed);
             }
             catch (error) {

--- a/package.json
+++ b/package.json
@@ -35,12 +35,14 @@
   "license": "MIT",
   "devDependencies": {
     "event-stream": "^3.3.2",
-    "mocha": "^2.2.5"
+    "mocha": "^2.2.5",
+    "vinyl": "^2.1.0"
   },
   "dependencies": {
     "bufferstreams": "1.1.0",
-    "gulp-util": "^3.0.6",
     "js-yaml": "^3.4.3",
+    "plugin-error": "^1.0.1",
+    "replace-ext": "^1.0.0",
     "through2": "^2.0.0",
     "xtend": "^4.0.0"
   }

--- a/test.js
+++ b/test.js
@@ -1,8 +1,8 @@
 /*global describe, it*/
 
 var yaml        = require('./');
-var File        = require('gulp-util').File;
-var PluginError = require('gulp-util').PluginError;
+var Vinyl       = require('vinyl');
+var PluginError = require('plugin-error');
 var es          = require('event-stream');
 var assert      = require('assert');
 var Readable    = require('stream').Readable;
@@ -20,7 +20,7 @@ describe('gulp-yaml', function() {
       else if (Array.isArray(contents)) {
         contents = new Buffer(contents.join('\n'), 'utf8');
       }
-      return new File({
+      return new Vinyl({
         cwd: './',
         base: './test/',
         path: './test/' + (filename || 'mock.yml'),
@@ -134,7 +134,7 @@ describe('gulp-yaml', function() {
         callback.apply(this, arguments);
         this.push(null);
       };
-      return new File({
+      return new Vinyl({
         cwd: './',
         base: './test/',
         path: './test/' + (filename || 'mock.yml'),


### PR DESCRIPTION
[`gulp-util`](https://www.npmjs.com/package/gulp-util) has been deprecated recently. Continuing to use this dependency may prevent the use of your library with the recently released version 4 of Gulp.

The [README.md](https://github.com/gulpjs/gulp-util) lists alternatives for all the components so a simple replacement should be enough.

Your package is popular but still relying on `gulp-util`, it would be good to publish a fixed version to npm as soon as possible.

See:
- https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
- https://github.com/gulpjs/gulp-util/issues/143