### PR TITLE
Snyk security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -184,27 +184,9 @@
       "dev": true
     },
     "bufferstreams": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-2.0.0.tgz",
-      "integrity": "sha512-P550SjDS31p36SbW6JVzuxtTIT6uMP5YxPAoIWMQR9m4+PXS8whQddUhoAutIeTOvM1QTxIf93cGWdD/Q1PlCQ==",
+      "version": "git+https://github.com/ehmicky/bufferstreams.git#2719573bc0854c2d3193ad8d44785d630fdd9748",
       "requires": {
-        "debug": "2.6.1",
         "readable-stream": "2.3.6"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz",
-          "integrity": "sha1-eYVQkLosTjEVzH2HaUkdWPBJE1E=",
-          "requires": {
-            "ms": "0.7.2"
-          }
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
-        }
       }
     },
     "builtin-modules": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "vinyl": "^2.1.0"
   },
   "dependencies": {
-    "bufferstreams": "^2.0.0",
+    "bufferstreams": "git+https://github.com/ehmicky/bufferstreams.git",
     "js-yaml": "^3.11.0",
     "object-assign": "^4.1.1",
     "plugin-error": "^1.0.1",


### PR DESCRIPTION
A [security vulnerability](https://snyk.io/test/npm/gulp-yaml) is reported by Snyk.

This is because the `bufferstreams` dependency depends on an old version of `debug` which has a RegExp DoS vulnerability. This actually is a non-problem since `bufferstreams` does not even use `debug` (although it declares it as a dependency). I've sent a [pull request](https://github.com/nfroidure/bufferstreams/pull/8) to remove that unused dependency.

Considering the projects seems mostly dormant, it might a while before they merge it, so I am suggesting to use my fork in the meantime.