### PR TITLE
Update version of js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "bufferstreams": "^2.0.1",
-    "js-yaml": "^3.12.1",
+    "js-yaml": "^3.13.1",
     "object-assign": "^4.1.1",
     "plugin-error": "^1.0.1",
     "replace-ext": "^1.0.0",


### PR DESCRIPTION
I'm getting warning from NPM because of previous version of js-yaml. Please make this change available to avoid getting high level warning from npm

```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Code Injection                                               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ js-yaml                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ gulp-yaml [dev]                                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ gulp-yaml > js-yaml                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/813                             │
└───────────────┴──────────────────────────────────────────────────────────────┘
```

https://npmjs.com/advisories/813